### PR TITLE
Allow attachments

### DIFF
--- a/lib/broker.go
+++ b/lib/broker.go
@@ -159,8 +159,8 @@ func (w *WriteThread) Start() {
 				}
 				ejson = stupidUTFHack(e)
 			}
-			if matches, _ := regexp.MatchString(`<[hH#@].+>`, string(ejson)); matches {
-				Logger.Debug(`message formtting detected; sending via api`)
+			if matches, _ := regexp.MatchString(`<[hH#@].+>`, string(ejson)); matches || e.Attachments != nil {
+				Logger.Debug(`message formatting detected; sending via api`)
 				e.Broker = w.broker
 				apiPostMessage(e)
 			} else {

--- a/lib/slackTypes.go
+++ b/lib/slackTypes.go
@@ -32,9 +32,9 @@ type Event struct {
 	UserName     string       `json:"username,omitempty"`
 	BotID        string       `json:"bot_id,omitempty"`
 	Subtype      string       `json:"subtype,omitempty"`
-	Ts           string       `json:"ts,omitempty,omitempty"`
+	Ts           string       `json:"ts,omitempty"`
 	Broker       *Broker
-	CallBackCode string `json:"callbackcode",omitempty,omitempty"`
+	CallBackCode string `json:"callbackcode,omitempty"`
 	Extra        map[string]interface{}
 }
 
@@ -51,6 +51,7 @@ type Attachment struct {
 	Fields     []AttachmentField `json:"fields,omitempty"`
 	ImageUrl   string            `json:"image_url,omitempty"`
 	ThumbUrl   string            `json:"thumb_url,omitempty"`
+	MarkdownIn []string          `json:"mrkdwn_in,omitempty"`
 }
 
 type AttachmentField struct {

--- a/lib/slackTypes.go
+++ b/lib/slackTypes.go
@@ -23,18 +23,40 @@ type ApiResponse struct {
 }
 
 type Event struct {
-	ID           int32  `json:"id,omitempty"`
-	Type         string `json:"type,omitempty"`
-	Channel      string `json:"channel,omitempty"`
-	Text         string `json:"text,omitempty"`
-	User         string `json:"user,omitempty"`
-	UserName     string `json:"username,omitempty"`
-	BotID        string `json:"bot_id,omitempty"`
-	Subtype      string `json:"subtype,omitempty"`
-	Ts           string `json:"ts,omitempty,omitempty"`
+	ID           int32        `json:"id,omitempty"`
+	Type         string       `json:"type,omitempty"`
+	Channel      string       `json:"channel,omitempty"`
+	Text         string       `json:"text,omitempty"`
+	Attachments  []Attachment `json:"attachments,omitempty"`
+	User         string       `json:"user,omitempty"`
+	UserName     string       `json:"username,omitempty"`
+	BotID        string       `json:"bot_id,omitempty"`
+	Subtype      string       `json:"subtype,omitempty"`
+	Ts           string       `json:"ts,omitempty,omitempty"`
 	Broker       *Broker
 	CallBackCode string `json:"callbackcode",omitempty,omitempty"`
 	Extra        map[string]interface{}
+}
+
+type Attachment struct {
+	Fallback   string            `json:"fallback"`
+	Color      string            `json:"color,omitempty"`
+	Pretext    string            `json:"pretext,omitempty"`
+	AuthorName string            `json:"author_name,omitempty"`
+	AuthorLink string            `json:"author_link,omitempty"`
+	AuthorIcon string            `json:"author_icon,omitempty"`
+	Title      string            `json:"title,omitempty"`
+	TitleLink  string            `json:"title_link,omitempty"`
+	Text       string            `json:"text,omitempty"`
+	Fields     []AttachmentField `json:"fields,omitempty"`
+	ImageUrl   string            `json:"image_url,omitempty"`
+	ThumbUrl   string            `json:"thumb_url,omitempty"`
+}
+
+type AttachmentField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short,omitempty"`
 }
 
 type User struct {


### PR DESCRIPTION
Allows the use of [attachments](https://api.slack.com/docs/attachments).

Usage example modules/help.go replacement (responds on same channel):

``` go
package modules

import (
    lazlo "github.com/djosephsen/lazlo/lib"
    "strings"
)

var Help = &lazlo.Module{
    Name:  `Help`,
    Usage: `"%BOTNAME% help": prints the usage information of every registered plugin`,
    Run:   helpRun,
}

func helpRun(b *lazlo.Broker) {
    cb := b.MessageCallback(`(?i)help`, true)
    for {
        pm := <-cb.Chan
        go getHelp(b, &pm)
    }
}

func getHelp(b *lazlo.Broker, pm *lazlo.PatternMatch) {
    a := []lazlo.Attachment{
        lazlo.Attachment{
            Color:  "#ff0000",
            Title:  "Modules In use",
            Fields: []lazlo.AttachmentField{},
        },
    }
    for _, m := range b.Modules {
        if strings.Contains(m.Usage, `%HIDDEN%`) {
            continue
        }
        usage := strings.Replace(m.Usage, `%BOTNAME%`, b.Config.Name, -1)

        a[0].Fields = append(a[0].Fields, lazlo.AttachmentField{
            Title: m.Name,
            Value: usage,
        })
    }
    pm.Event.RespondAttachments(a)
}
```
